### PR TITLE
moved js includes to bottom of layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,10 +4,6 @@
   <title>MyNewApp</title>
   <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  
-  <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>  
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>
@@ -15,5 +11,8 @@
   <h2>Buy musical instruments and props here</h2>
 <%= yield %>
 
+  <%= javascript_include_tag '//code.jquery.com/jquery-1.11.2.min.js' %>
+  <%= javascript_include_tag '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js' %>
+  <%= javascript_include_tag :application, 'data-turbolinks-track' => true %>
 </body>
 </html>


### PR DESCRIPTION
Hi Antonia,

Here's your first Pull Request! :smile: 
I moved the Javascript includes to the bottom of the footer. It is recommended to put them there (unlike the stylesheets, which should be at the top) so they don't hold up the page load.
If you accept this pull request, my commit will be merged into your repo, and you can do a "git pull" on your local machine to have it there, too!

Let me know if you have any questions!

Cheers,
Manuel
